### PR TITLE
improve: reduce stack trace by removing useless function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 # mali-compose
 
+[![Greenkeeper badge](https://badges.greenkeeper.io/malijs/mali-compose.svg)](https://greenkeeper.io/)
+
 Compose middleware.
 
 Basically copy of [koa-compose](https://github.com/koajs/compose).

--- a/index.js
+++ b/index.js
@@ -25,9 +25,7 @@ function compose (middleware) {
       if (i === middleware.length) fn = next
       if (!fn) return Promise.resolve()
       try {
-        return Promise.resolve(fn(context, function next () {
-          return dispatch(i + 1)
-        }))
+        return Promise.resolve(fn(context, dispatch.bind(null, i + 1)))
       } catch (err) {
         return Promise.reject(err)
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {},
   "devDependencies": {
     "codecov": "^3.0.0",
-    "jest": "^21.0.0",
+    "jest": "^22.1.4",
     "matcha": "^0.7.0",
     "standard": "^10.0.3"
   },


### PR DESCRIPTION
update from koa-compose

### Before

```
                      compose
       1,283,509 op/s » (fn * 1)
         631,856 op/s » (fn * 2)
         323,821 op/s » (fn * 4)
         170,790 op/s » (fn * 8)
          86,148 op/s » (fn * 16)
          44,432 op/s » (fn * 32)
          21,890 op/s » (fn * 64)
          11,004 op/s » (fn * 128)
           5,523 op/s » (fn * 256)
           2,671 op/s » (fn * 512)
           1,294 op/s » (fn * 1024)
```
  Suites:  1
  Benches: 11
  Elapsed: 17,812.50 ms


### After

 ```
                     compose
       1,306,215 op/s » (fn * 1)
         683,205 op/s » (fn * 2)
         352,461 op/s » (fn * 4)
         181,936 op/s » (fn * 8)
          93,017 op/s » (fn * 16)
          47,060 op/s » (fn * 32)
          23,650 op/s » (fn * 64)
          11,906 op/s » (fn * 128)
           5,858 op/s » (fn * 256)
           2,858 op/s » (fn * 512)
           1,383 op/s » (fn * 1024)
```

  Suites:  1
  Benches: 11
  Elapsed: 18,720.14 ms

### Before

```
        at stack.push (/Users/popomore/projj/github.com/koajs/compose/test/test.js:40:19)
        at dispatch (/Users/popomore/projj/github.com/koajs/compose/index.js:42:32)
        at next (/Users/popomore/projj/github.com/koajs/compose/index.js:43:18)
        at stack.push (/Users/popomore/projj/github.com/koajs/compose/test/test.js:32:13)
        at dispatch (/Users/popomore/projj/github.com/koajs/compose/index.js:42:32)
        at next (/Users/popomore/projj/github.com/koajs/compose/index.js:43:18)
        at stack.push (/Users/popomore/projj/github.com/koajs/compose/test/test.js:24:13)
        at dispatch (/Users/popomore/projj/github.com/koajs/compose/index.js:42:32)
        at /Users/popomore/projj/github.com/koajs/compose/index.js:34:12
        at Object.it.only (/Users/popomore/projj/github.com/koajs/compose/test/test.js:46:25)
```

### After

```
        at stack.push (/Users/popomore/projj/github.com/koajs/compose/test/test.js:40:19)
        at dispatch (/Users/popomore/projj/github.com/koajs/compose/index.js:42:32)
        at stack.push (/Users/popomore/projj/github.com/koajs/compose/test/test.js:32:13)
        at dispatch (/Users/popomore/projj/github.com/koajs/compose/index.js:42:32)
        at stack.push (/Users/popomore/projj/github.com/koajs/compose/test/test.js:24:13)
        at dispatch (/Users/popomore/projj/github.com/koajs/compose/index.js:42:32)
        at /Users/popomore/projj/github.com/koajs/compose/index.js:34:12
        at Object.it.only (/Users/popomore/projj/github.com/koajs/compose/test/test.js:46:25)
```